### PR TITLE
verify() tests an unknown value

### DIFF
--- a/src/Poet.php
+++ b/src/Poet.php
@@ -98,7 +98,7 @@ class Poet
     /**
      * Checks if the passed object is a valid WP_Post_Type or WP_Taxonomy instance.
      *
-     * @param  object $object
+     * @param  mixed $object
      * @return bool
      */
     protected function verify($object)


### PR DESCRIPTION
`$object` may have the type `WP_Post_Type|WP_Taxonomy|false`

_discovered by @phpstan_
