### PR TITLE
Add block category support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.0.7 (04/30/20)
+
+- feat(poet): Add block category support
+- fix(post): Fix post type registration when using multiple string keys.
+- fix(taxonomy): Fix taxonomy registration when using multiple string keys.
+- enhance(poet): Make the post type, taxonomy, and block registration loop more performant.
+- chore(deps): Bump dependencies
+- chore(docs): Add block category examples to README
+
 ## v1.0.6 (03/31/20)
 
 - fix(post): Actually fix post type registration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Build Status](https://img.shields.io/circleci/build/github/Log1x/poet?style=flat-square)
 ![Total Downloads](https://img.shields.io/packagist/dt/log1x/poet?style=flat-square)
 
-Poet provides simple configuration-based post type and taxonomy registration as well as the ability to register Gutenberg blocks to be rendered with Laravel Blade.
+Poet provides simple configuration-based post type, taxonomy, and block category registration as well as the ability to register Gutenberg blocks rendered with Laravel Blade.
 
 Post types and taxonomies are registered utilizing [Extended CPTs](https://github.com/johnbillion/extended-cpts).
 
@@ -141,6 +141,63 @@ For additional configuration options for taxonomies, please see:
 - [`register_extended_taxonomy()`](https://github.com/johnbillion/extended-cpts/wiki/Registering-taxonomies).
 
 > **Note**: Do not nest configuration in a `config` key like shown in the Extended CPTs documentation.
+
+### Register a Block Category
+
+Poet provides an easy to way register, modify, and unregister Gutenberg block categories. Looking in the config, you will see a commented out example for a Call to Action category:
+
+```php
+'categories' => [
+    'cta' => [
+        'title' => 'Call to Action',
+        'icon' => 'star-filled',
+    ],
+],
+```
+
+This would result in a block category with a slug of `cta`. Once your block category is registered, you must register a block to its slug before the category will appear in the editor.
+
+In it's simplest form, you can simply pass a string:
+
+```php
+'categories' => [
+    'my-cool-blocks',
+],
+```
+
+which would result in a `my-cool-blocks` category automatically converting the slug to title case.
+
+You can also specify the title by passing a value to your slug:
+
+```php
+'categories' => [
+    'my-cool-blocks' => 'Best Blocks, World.',
+],
+```
+
+Like post types and taxonomies, modifying an existing block category is the same as registering one:
+
+```php
+'categories' => [
+    'common' => ['icon' => 'star-filled']
+],
+```
+
+You can also easily rename existing categories by passing it a string instead of an array:
+
+```php
+'categories' => [
+    'common' => 'Uncommon Blocks',
+],
+```
+
+You can unregister an existing block category by simply passing `false`:
+
+```php
+'categories' => [
+    'common' => false,
+],
+```
 
 ### Registering a Block
 

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "johnbillion/extended-cpts",
-            "version": "4.3.2",
+            "version": "4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/extended-cpts.git",
-                "reference": "6446170b222869e1e0770c130ead47def5261b51"
+                "reference": "4c4e292781c28a7d8666803f63c44e655cddf7ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/extended-cpts/zipball/6446170b222869e1e0770c130ead47def5261b51",
-                "reference": "6446170b222869e1e0770c130ead47def5261b51",
+                "url": "https://api.github.com/repos/johnbillion/extended-cpts/zipball/4c4e292781c28a7d8666803f63c44e655cddf7ad",
+                "reference": "4c4e292781c28a7d8666803f63c44e655cddf7ad",
                 "shasum": ""
             },
             "require": {
@@ -33,7 +33,7 @@
                 "roots/wordpress": "*",
                 "vlucas/phpdotenv": "^3",
                 "wp-cli/wp-cli-bundle": "^2.1",
-                "wp-coding-standards/wpcs": "^2",
+                "wp-coding-standards/wpcs": "~2.1.0",
                 "wp-phpunit/wp-phpunit": "*"
             },
             "suggest": {
@@ -64,22 +64,22 @@
             ],
             "description": "A library which provides extended functionality to WordPress custom post types and taxonomies.",
             "homepage": "https://github.com/johnbillion/extended-cpts/",
-            "time": "2019-08-25T21:14:07+00:00"
+            "time": "2020-04-22T16:13:18+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "version": "3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
             "require": {
@@ -117,7 +117,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "time": "2020-04-17T01:09:41+00:00"
         }
     ],
     "aliases": [],
@@ -128,5 +128,6 @@
     "platform": {
         "php": ">=7.2.5"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/config/poet.php
+++ b/config/poet.php
@@ -74,8 +74,8 @@ return [
     | Block Categories
     |--------------------------------------------------------------------------
     |
-    | Here you may specify block categories to be registered or unregistered
-    | by Poet for use in the editor.
+    | Here you may specify block categories to be registered by Poet for use
+    | in the editor.
     |
     */
 

--- a/config/poet.php
+++ b/config/poet.php
@@ -66,6 +66,24 @@ return [
     */
 
     'block' => [
-        // 'sage/accordion'
+        // 'sage/accordion',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Block Categories
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify block categories to be registered or unregistered
+    | by Poet for use in the editor.
+    |
+    */
+
+    'categories' => [
+        // 'cta' => [
+        //     'title' => 'Call to Action',
+        //     'icon' => 'star-filled',
+        // ],
+    ],
+
 ];

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -165,7 +165,7 @@ class Poet
 
     /**
      * Register the configured block categories with the editor.
-
+     *
      * If a category already exists, it will be modified instead.
      *
      * If a category already exists and is set to `false`, the taxonomy

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -168,7 +168,7 @@ class Poet
      *
      * If a category already exists, it will be modified instead.
      *
-     * If a category already exists and is set to `false`, the taxonomy
+     * If a category already exists and is set to `false`, the category
      * will be unregistered.
      *
      * @return void


### PR DESCRIPTION
* feat(poet): Add block category support
* fix(post): Fix post type registration when using multiple string keys.
* fix(taxonomy): Fix taxonomy registration when using multiple string keys.
* enhance(poet): Make the post type, taxonomy, and block registration loop more performant.
* chore(deps): Bump dependencies
* chore(docs): Add block category examples to README