### PR TITLE
Compatibility: Allow for missing array keys

### DIFF
--- a/src/Poet.php
+++ b/src/Poet.php
@@ -32,13 +32,13 @@ class Poet
         $this->config = collect($config)->mapInto(Collection::class);
 
         add_filter('init', function () {
-            $this->registerPosts();
-            $this->registerAnchors();
-            $this->registerTaxonomies();
-            $this->registerBlocks();
-            $this->registerCategories();
-            $this->registerPalette();
-            $this->registerMenu();
+            $this->config->has('post') && $this->registerPosts();
+            $this->config->has('post') && $this->registerAnchors();
+            $this->config->has('taxonomy') && $this->registerTaxonomies();
+            $this->config->has('block') && $this->registerBlocks();
+            $this->config->has('categories') && $this->registerCategories();
+            $this->config->has('palette') && $this->registerPalette();
+            $this->config->has('menu') && $this->registerMenu();
         }, 20);
     }
 


### PR DESCRIPTION
All the new features of Poet are great, but Poet should check to make sure they're being utilized before firing them. In my case the `block` array key doesn't exist, but I don't have use for that feature on this particular site. 