### PR TITLE
Fixes issue for translating custom post type slugs with WPML

### DIFF
--- a/src/Poet.php
+++ b/src/Poet.php
@@ -39,7 +39,7 @@ class Poet
             $this->config->has('categories') && $this->registerCategories();
             $this->config->has('palette') && $this->registerPalette();
             $this->config->has('menu') && $this->registerMenu();
-        }, 20);
+        }, 10);
     }
 
     /**

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -39,7 +39,7 @@ class Poet
             $this->config->has('categories') && $this->registerCategories();
             $this->config->has('palette') && $this->registerPalette();
             $this->config->has('menu') && $this->registerMenu();
-        }, 10);
+        });
     }
 
     /**


### PR DESCRIPTION
Translating slugs with WPML are not working because of the priority used by Poet to register custom post types.

See:
https://wpml.org/forums/topic/post_type-slugs-are-set-to-be-translated-but-they-are-missing-their-translation/#post-4667347