### PR TITLE
Fix: FaceWP compatibility

### DIFF
--- a/src/Poet.php
+++ b/src/Poet.php
@@ -69,6 +69,6 @@ class Poet
 
                 new $module($this->app, $this->config);
             }
-        },19);
+        }, 19);
     }
 }

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -69,6 +69,6 @@ class Poet
 
                 new $module($this->app, $this->config);
             }
-        }, 20);
+        },19);
     }
 }

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -69,6 +69,6 @@ class Poet
 
                 new $module($this->app, $this->config);
             }
-        }, 19);
+        });
     }
 }


### PR DESCRIPTION
With priority 20 FacetWP won't index the post types, changing it to 19 works.

Any reason it's set to 20? (and not  to 0)