### PR TITLE
Fix error when querying post types by taxonomy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Registering a taxonomy is similar to a post type. Looking in `config/poet.php`, 
 
 The most relevent configuration option is `links` which defines the post type the taxonomy is connected to. If no link is specified, it will default to `post`.
 
-To view an archive for the Genre taxonomy, copy the Blade template called `archive.blade.php` to a new file called  `taxonomy-genre.blade.php`.
+To view an archive for the Genre taxonomy, copy the Blade template called `archive.blade.php` to a new file called `taxonomy-genre.blade.php`.
 
 In it's simplest form, you can simply pass a string. The example below would create a Topic taxonomy for the Post post type:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Registering a taxonomy is similar to a post type. Looking in `config/poet.php`, 
 
 The most relevent configuration option is `links` which defines the post type the taxonomy is connected to. If no link is specified, it will default to `post`.
 
+To view an archive for the Genre taxonomy, copy the Blade template called `archive.blade.php` to a new file called  `taxonomy-genre.blade.php`.
+
 In it's simplest form, you can simply pass a string. The example below would create a Topic taxonomy for the Post post type:
 
 ```php

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -43,8 +43,8 @@ class Poet
         BlockCategoryModule::class,
         BlockModule::class,
         EditorPaletteModule::class,
-        PostTypeModule::class,
         TaxonomyModule::class,
+        PostTypeModule::class,
     ];
 
     /**


### PR DESCRIPTION
Post types expect that the taxonomies they are registered with exist
in the database. Therefore, we register the taxonomies first and then
we register the post types.

Fixes #26.