### PR TITLE
feat: add support for registering block patterns with blade partials as content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 ![Build Status](https://img.shields.io/github/workflow/status/log1x/poet/Main?style=flat-square)
 ![Total Downloads](https://img.shields.io/packagist/dt/log1x/poet?style=flat-square)
 
-Poet provides simple configuration-based post type, taxonomy, editor color palette, block category, and block registration/modification.
+Poet provides simple configuration-based post type, taxonomy, editor color palette, block category, block pattern and block registration/modification.
 
 ## Features
 
 - Dead simple post type and taxonomy registration, modification, and unregistering powered by [Extended CPTs](https://github.com/johnbillion/extended-cpts).
 - Easy editor color palette configuration including built-in support for [webpack-palette-plugin](https://github.com/roots/palette-webpack-plugin).
 - Blocks registered are rendered using Laravel Blade on the frontend.
+- Block Patterns registered can have their content defined using Laravel Blade too.
 - Add additional block categories with nothing more than a slug.
 - Move parent admin menu items to the `Tools` submenu using their page slug.
 
@@ -262,6 +263,49 @@ You can unregister an existing block category by simply passing `false`:
 'block_category' => [
     'common' => false,
 ],
+```
+
+### Registering a Block Pattern
+
+Poet can also register Block Patterns for you, with an optional Blade view for the content.
+
+Patterns are registered using the `namespace/label` defined when [registering the pattern with the editor](https://developer.wordpress.org/reference/functions/register_block_pattern/).
+
+If no namespace is provided, the current theme's [text domain](https://developer.wordpress.org/themes/functionality/internationalization/#loading-text-domain) will be used instead.
+
+Registering a block in most cases is as simple as:
+
+```php
+'block_pattern' => [
+    'sage/hero' => [
+        'title' => 'Page Hero',
+        'description' => 'Draw attention to the main focus of the page, and highlight key CTAs',
+    ],
+],
+```
+
+You can register the actual content for the pattern here as well, using the `content` key. Or leave it blank to use a corresponding blade view.
+
+```php
+'block_pattern' => [
+    'sage/fake-paragraph' => [
+        'title' => 'Fake Paragraph',
+        'description' => 'Filler content used instead of actual content for testing purposes',
+        'content' => '<!-- wp:paragraph --><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione nulla culpa repudiandae nisi nostrum et, labore earum repellendus porro, mollitia voluptas quam? Modi sint tempore deleniti nesciunt ab, perferendis et.</p><!-- /wp:paragraph -->',
+    ],
+],
+```
+
+#### Creating a Pattern View
+
+Given the block `sage/fake-paragraph`, if no `content` key is defined, then your accompanying Blade view would be located at `views/block-patterns/fake-paragraph.blade.php`.
+
+This Block Pattern view may look like this:
+
+```php
+<!-- wp:paragraph -->
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione nulla culpa repudiandae nisi nostrum et, labore earum repellendus porro, mollitia voluptas quam? Modi sint tempore deleniti nesciunt ab, perferendis et.</p>
+<!-- /wp:paragraph -->
 ```
 
 ### Registering an Editor Color Palette

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Registering a block in most cases is as simple as:
     'sage/hero' => [
         'title' => 'Page Hero',
         'description' => 'Draw attention to the main focus of the page, and highlight key CTAs',
+        'categories' => ['all'],
     ],
 ],
 ```
@@ -291,6 +292,7 @@ You can register the actual content for the pattern here as well, using the `con
     'sage/fake-paragraph' => [
         'title' => 'Fake Paragraph',
         'description' => 'Filler content used instead of actual content for testing purposes',
+        'categories' => ['all'],
         'content' => '<!-- wp:paragraph --><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione nulla culpa repudiandae nisi nostrum et, labore earum repellendus porro, mollitia voluptas quam? Modi sint tempore deleniti nesciunt ab, perferendis et.</p><!-- /wp:paragraph -->',
     ],
 ],
@@ -307,6 +309,22 @@ This Block Pattern view may look like this:
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione nulla culpa repudiandae nisi nostrum et, labore earum repellendus porro, mollitia voluptas quam? Modi sint tempore deleniti nesciunt ab, perferendis et.</p>
 <!-- /wp:paragraph -->
 ```
+
+### Registering a Block Pattern Category
+
+Block Pattern Categories can be added with the following code in the poet config:
+
+```php
+'block_pattern_category' => [
+    'all' => [
+        'label' => 'All Patterns',
+    ],
+],
+```
+
+You can specify all category properties such as `label`, as per the [block editor handbook](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-patterns/#register_block_pattern_category).
+
+> Note: Currently, if no Block Pattern Categories are available at all, the Block Patterns tab in the editor will crash when clicked on.
 
 ### Registering an Editor Color Palette
 

--- a/config/poet.php
+++ b/config/poet.php
@@ -108,7 +108,24 @@ return [
         // 'sage/hero' => [
         //     'title' => 'Page Hero',
         //     'description' => 'Draw attention to the main focus of the page, and highlight key CTAs',
+        //     'categories' => ['all'],
         // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Block Pattern Categories
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify block pattern categories to be registered by Poet for
+    | use in the editor.
+    |
+    */
+
+    'block_pattern_category' => [
+        'all' => [
+            'label' => 'All Patterns',
+        ],
     ],
 
     /*

--- a/config/poet.php
+++ b/config/poet.php
@@ -88,6 +88,31 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Block Patterns
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify block patterns to be registered by Poet for use
+    | in the editor.
+    |
+    | Patterns are registered using the `namespace/label` defined when
+    | registering the block with the editor. If no namespace is provided,
+    | the current theme text domain will be used instead.
+    |
+    | Given the pattern `sage/hero`, your pattern content would be located at:
+    |   ↪ `views/block-patterns/hero.blade.php`
+    |
+    | See: https://developer.wordpress.org/reference/functions/register_block_pattern/
+    */
+
+    'block_pattern' => [
+        // 'sage/hero' => [
+        //     'title' => 'Page Hero',
+        //     'description' => 'Draw attention to the main focus of the page, and highlight key CTAs',
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Editor Palette
     |--------------------------------------------------------------------------
     |

--- a/src/Concerns/HasNamespace.php
+++ b/src/Concerns/HasNamespace.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Log1x\Poet\Concerns;
+
+use Illuminate\Support\Str;
+
+trait HasNamespace
+{
+    /**
+     * Use the current theme's text domain as a namespace.
+     *
+     * @param string $delimiter
+     * @return string
+     */
+    protected function namespace($delimiter = '/')
+    {
+        return (Str::slug(
+            wp_get_theme()->get('TextDomain')
+        ) ?? 'sage') . $delimiter;
+    }
+}

--- a/src/Modules/BlockModule.php
+++ b/src/Modules/BlockModule.php
@@ -3,11 +3,14 @@
 namespace Log1x\Poet\Modules;
 
 use Illuminate\Support\Str;
+use Log1x\Poet\Concerns\HasNamespace;
 
 use function Roots\view;
 
 class BlockModule extends AbstractModule
 {
+    use HasNamespace;
+
     /**
      * The module key.
      *
@@ -43,19 +46,6 @@ class BlockModule extends AbstractModule
                 },
             ]);
         });
-    }
-
-    /**
-     * Use the current theme's text domain as a namespace.
-     *
-     * @param  string $delimiter
-     * @return string
-     */
-    protected function namespace($delimiter = '/')
-    {
-        return (Str::slug(
-            wp_get_theme()->get('TextDomain')
-        ) ?? 'sage') . $delimiter;
     }
 
     /**

--- a/src/Modules/BlockPatternCategoryModule.php
+++ b/src/Modules/BlockPatternCategoryModule.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Log1x\Poet\Modules;
+
+use Illuminate\Support\Str;
+
+class BlockPatternCategoryModule extends AbstractModule
+{
+    /**
+     * The module key.
+     *
+     * @var string
+     */
+    protected $key = 'block_pattern_category';
+
+    /**
+     * Handle the module.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        /** No need to load block pattern categories when loading the website frontend */
+        if (!is_admin() || !class_exists('WP_Block_Patterns_Registry')) {
+            return;
+        }
+
+        return $this->config->each(function ($categoryData, $categorySlug) {
+            if (empty($categorySlug) || is_int($categorySlug)) {
+                $categorySlug = $categoryData;
+                $categoryData = [];
+            }
+
+            register_block_pattern_category(Str::slug($categorySlug), $categoryData);
+        });
+    }
+}

--- a/src/Modules/BlockPatternModule.php
+++ b/src/Modules/BlockPatternModule.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Log1x\Poet\Modules;
+
+use Illuminate\Support\Str;
+use Log1x\Poet\Concerns\HasNamespace;
+use function Roots\view;
+
+class BlockPatternModule extends AbstractModule
+{
+    use HasNamespace;
+
+    /**
+     * The module key.
+     *
+     * @var string
+     */
+    protected $key = 'block_pattern';
+
+    /**
+     * Handle the module.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        /** No need to load block patterns when loading the website frontend */
+        if (!is_admin() || !class_exists('WP_Block_Patterns_Registry')) {
+            return;
+        }
+
+        return $this->config->each(function ($patternData, $patternSlug) {
+            if (empty($patternSlug) || is_int($patternSlug)) {
+                return;
+            }
+
+            $patternData = $this->collect($patternData);
+
+            if (!Str::contains($patternSlug, '/')) {
+                $patternSlug = Str::start($patternSlug, $this->namespace());
+            }
+
+            $viewSlug = 'block-patterns.' . Str::after($patternSlug, '/');
+
+            if (!view()->exists($viewSlug)) {
+                return;
+            }
+
+            if (!$patternData->has('content')) {
+                $patternData['content'] = view($viewSlug)->render();
+            }
+
+            return register_block_pattern($patternSlug, $patternData->all());
+        });
+    }
+}

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -8,6 +8,7 @@ use Log1x\Poet\Modules\AbstractModule;
 use Log1x\Poet\Modules\AdminMenuModule;
 use Log1x\Poet\Modules\BlockCategoryModule;
 use Log1x\Poet\Modules\BlockModule;
+use Log1x\Poet\Modules\BlockPatternModule;
 use Log1x\Poet\Modules\EditorPaletteModule;
 use Log1x\Poet\Modules\PostTypeModule;
 use Log1x\Poet\Modules\TaxonomyModule;
@@ -42,6 +43,7 @@ class Poet
         AdminMenuModule::class,
         BlockCategoryModule::class,
         BlockModule::class,
+        BlockPatternModule::class,
         EditorPaletteModule::class,
         TaxonomyModule::class,
         PostTypeModule::class,

--- a/src/Poet.php
+++ b/src/Poet.php
@@ -8,6 +8,7 @@ use Log1x\Poet\Modules\AbstractModule;
 use Log1x\Poet\Modules\AdminMenuModule;
 use Log1x\Poet\Modules\BlockCategoryModule;
 use Log1x\Poet\Modules\BlockModule;
+use Log1x\Poet\Modules\BlockPatternCategoryModule;
 use Log1x\Poet\Modules\BlockPatternModule;
 use Log1x\Poet\Modules\EditorPaletteModule;
 use Log1x\Poet\Modules\PostTypeModule;
@@ -44,6 +45,7 @@ class Poet
         BlockCategoryModule::class,
         BlockModule::class,
         BlockPatternModule::class,
+        BlockPatternCategoryModule::class,
         EditorPaletteModule::class,
         TaxonomyModule::class,
         PostTypeModule::class,


### PR DESCRIPTION
This would close #13 

# Description
Following on from the discussion in #13, this PR adds support for registering Block Patterns.

A new BlockPatternModule is added and registered with Poet. It then takes config via `config/poet.php` under the `block_pattern` key, and registers the patterns in a similar way to how Blocks are registered.

Note: The `namespace()` method from the `BlockModule` is also required for Block Patterns. I've moved this method to a `HasNamespace` trait, which both the `BlockModule` and `BlockPatternModule` now use.

# Docs

### Registering a Block Pattern

Poet can also register Block Patterns for you, with an optional Blade view for the content.

Patterns are registered using the `namespace/label` defined when [registering the pattern with the editor](https://developer.wordpress.org/reference/functions/register_block_pattern/).

If no namespace is provided, the current theme's [text domain](https://developer.wordpress.org/themes/functionality/internationalization/#loading-text-domain) will be used instead.

Registering a block in most cases is as simple as:

```php
'block_pattern' => [
    'sage/hero' => [
        'title' => 'Page Hero',
        'description' => 'Draw attention to the main focus of the page, and highlight key CTAs',
    ],
],
```

You can register the actual content for the pattern here as well, using the `content` key. Or leave it blank to use a corresponding blade view.

```php
'block_pattern' => [
    'sage/fake-paragraph' => [
        'title' => 'Fake Paragraph',
        'description' => 'Filler content used instead of actual content for testing purposes',
        'content' => '<!-- wp:paragraph --><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione nulla culpa repudiandae nisi nostrum et, labore earum repellendus porro, mollitia voluptas quam? Modi sint tempore deleniti nesciunt ab, perferendis et.</p><!-- /wp:paragraph -->',
    ],
],
```

#### Creating a Pattern View

Given the block `sage/fake-paragraph`, if no `content` key is defined, then your accompanying Blade view would be located at `views/block-patterns/fake-paragraph.blade.php`.

This Block Pattern view may look like this:

```php
<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione nulla culpa repudiandae nisi nostrum et, labore earum repellendus porro, mollitia voluptas quam? Modi sint tempore deleniti nesciunt ab, perferendis et.</p>
<!-- /wp:paragraph -->
```