### PR TITLE
Fix Blocks Patterns & Blocks Pattern Categories Registration: Remove `is_admin()` condition

### DIFF
--- a/src/Modules/BlockPatternCategoryModule.php
+++ b/src/Modules/BlockPatternCategoryModule.php
@@ -20,7 +20,7 @@ class BlockPatternCategoryModule extends AbstractModule
      */
     public function handle()
     {
-        if (! is_admin() || ! class_exists('WP_Block_Patterns_Registry')) {
+        if (! class_exists('WP_Block_Patterns_Registry')) {
             return;
         }
 

--- a/src/Modules/BlockPatternModule.php
+++ b/src/Modules/BlockPatternModule.php
@@ -25,7 +25,7 @@ class BlockPatternModule extends AbstractModule
      */
     public function handle()
     {
-        if (! is_admin() || ! class_exists('WP_Block_Patterns_Registry')) {
+        if (! class_exists('WP_Block_Patterns_Registry')) {
             return;
         }
 


### PR DESCRIPTION
`is_admin()` is not reliable in this conext. Block Pattern Categories are not available in the editor as long as the condition is used.