### PR TITLE
Allow post types to also be moved

### DIFF
--- a/src/Modules/AdminMenuModule.php
+++ b/src/Modules/AdminMenuModule.php
@@ -22,7 +22,8 @@ class AdminMenuModule extends AbstractModule
     {
         add_filter('admin_menu', function () {
             $this->config = $this->config->mapWithKeys(function ($value, $key) {
-                $page = admin_url("admin.php?page={$value}");
+                $url = post_type_exists($value) ? "edit.php?post_type={$value}" : "admin.php?page={$value}";
+                $page = admin_url($url);
 
                 return is_int($key) ? [$value => $page] : [$key => $page];
             });


### PR DESCRIPTION
This small change allow move ACF settings page and any other custom post type page.